### PR TITLE
Add symbolic link pointing to escript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ out/
 
 # General
 .DS_Store
+
+### Other
+cauder

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ fail with the following error: `{error,{not_started,cauder}}`
 
 ℹ️ This will block the current shell until the CauDEr window is closed.
 
+In Unix systems a symbolic link pointing to `./_build/default/bin/cauder` will
+be created in the root of the project.
+
 ### Using the release
 
     ./_build/default/reltool/cauder

--- a/_checkouts/cauder_plugin/src/cauder_plugin.erl
+++ b/_checkouts/cauder_plugin/src/cauder_plugin.erl
@@ -9,6 +9,7 @@ init(State) ->
 init_providers(State) ->
   lists:foldl(fun init_provider/2, State, [
     cauder_plugin_prv_clean,
+    cauder_plugin_prv_escript_link,
     cauder_plugin_prv_reltool
   ]).
 

--- a/_checkouts/cauder_plugin/src/cauder_plugin_prv_clean.erl
+++ b/_checkouts/cauder_plugin/src/cauder_plugin_prv_clean.erl
@@ -27,8 +27,8 @@ init(State) ->
       {module, ?MODULE},
       {bare, true},
       {deps, ?DEPS},
-      {desc, "Creates a release of CauDEr using reltool"},
-      {short_desc, "Creates a release of CauDEr using reltool"},
+      {desc, "Removes extra files which `rebar3 clean -a` doesn't"},
+      {short_desc, "Removes extra files which `rebar3 clean -a` doesn't"},
       {example, "rebar3 " ++ atom_to_list(?PROVIDER)},
       {opts, []}
     ]),

--- a/_checkouts/cauder_plugin/src/cauder_plugin_prv_clean.erl
+++ b/_checkouts/cauder_plugin/src/cauder_plugin_prv_clean.erl
@@ -47,6 +47,7 @@ do(State) ->
     AppInfo ->
       case rebar_app_info:name(AppInfo) of
         <<"cauder">> ->
+          file:delete(filename:join(rebar_dir:root_dir(State), "cauder")),
           rebar_file_utils:rm_rf(rebar_dir:base_dir(State));
         _ ->
           ok

--- a/_checkouts/cauder_plugin/src/cauder_plugin_prv_escript_link.erl
+++ b/_checkouts/cauder_plugin/src/cauder_plugin_prv_escript_link.erl
@@ -1,0 +1,79 @@
+-module(cauder_plugin_prv_escript_link).
+
+%% API
+-export([init/1, do/1, format_error/1]).
+
+-include_lib("kernel/include/file.hrl").
+
+-define(PROVIDER, ?MODULE).
+-define(DEPS, []).
+
+
+%%%=============================================================================
+%%% API
+%%%=============================================================================
+
+
+%% Called when rebar3 first boots, before even parsing the arguments
+%% or commands to be run. Purely initiates the provider, and nothing
+%% else should be done here.
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+
+init(State) ->
+  Provider = providers:create(
+    [
+      {name, ?PROVIDER},
+      {module, ?MODULE},
+      {bare, true},
+      {deps, ?DEPS},
+      {desc, "Creates a symbolic link to the escript"},
+      {short_desc, "Creates a symbolic link to the escript"},
+      {example, "rebar3 " ++ atom_to_list(?PROVIDER)},
+      {opts, []}
+    ]),
+  {ok, rebar_state:add_provider(State, Provider)}.
+
+
+%% Run the code for the plugin. The command line argument are parsed
+%% and dependencies have been run.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+
+do(State) ->
+  case rebar_state:current_app(State) of
+    undefined ->
+      ok;
+    AppInfo ->
+      case rebar_app_info:name(AppInfo) of
+        <<"cauder">> ->
+          Escript = filename:join([rebar_dir:base_dir(State), "bin", "cauder"]),
+          Link = filename:join(rebar_dir:root_dir(State), "cauder"),
+          case os:type() of
+            {win32, _} ->
+              file:delete(Link);
+            {unix, _} ->
+              case file:make_symlink(Escript, Link) of
+                ok ->
+                  rebar_api:info("Created symbolic link: ~p -> ~p~n", [Link, Escript]);
+                {error, eexist} ->
+                  rebar_api:info("Symbolic link already exists~n", [])
+              end
+          end;
+        _ ->
+          ok
+      end
+  end,
+
+  {ok, State}.
+
+
+%% When an exception is raised or a value returned as
+%% `{error, {?MODULE, Reason}}` will see the `format_error(Reason)`
+%% function called for them, so a string can be formatted explaining
+%% the issue.
+
+-spec format_error(any()) -> iolist().
+
+format_error(Reason) ->
+  io_lib:format("~p", [Reason]).

--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,8 @@
 
 {provider_hooks,
   [
-    {post, [{clean, cauder_plugin_prv_clean}]}
+    {post, [
+      {clean, cauder_plugin_prv_clean},
+      {escriptize, cauder_plugin_prv_escript_link}
+    ]}
   ]}.


### PR DESCRIPTION
## Description

At the [request](https://listas.upv.es/mailman/private/cauder/2021-April/000012.html) of @lanese, now when running `./rebar3 escriptize` in Unix systems, a symbolic link pointing to `./_build/default/bin/cauder` will be created in the root of the project, making it easier to run CauDEr.