### PR TITLE
Add missing code to fully support `spawn/1` function

### DIFF
--- a/src/cauder_eval.erl
+++ b/src/cauder_eval.erl
@@ -198,7 +198,7 @@ expr(Bs, E = {spawn, Line, Fun}, Stk) ->
     true -> eval_and_update({Bs, Fun, Stk}, {3, E});
     false ->
       Var = cauder_utils:temp_variable(Line),
-      Label = {spawn, Var, concrete(Fun)},
+      Label = {spawn, Var, Fun},
       #result{env = Bs, exprs = [Var], stack = Stk, label = Label}
   end;
 

--- a/src/cauder_types.erl
+++ b/src/cauder_types.erl
@@ -62,7 +62,7 @@
 
 -type result() :: #result{}.
 -type label() :: tau
-               | {spawn, af_variable(), function()}
+               | {spawn, af_variable(), af_literal()}
                | {spawn, af_variable(), module(), atom(), [term()]}
                | {self, af_variable()}
                | {send, proc_id(), term()}


### PR DESCRIPTION
## Description

Some code was missing in the forwards semantics module to process labels from `spawn/1` evaluations

## Changes

- Add missing code to `cauder_semantics_forwards` module
- Fix type definition of the label for `spawn/1` evaluation in the `cauder_types` module

## References

This bug was reported via email
