### PR TITLE
Fix bug when scheduler's old and new PID lists have the same size

### DIFF
--- a/src/cauder.erl
+++ b/src/cauder.erl
@@ -1120,16 +1120,19 @@ step_multiple(Sem, Scheduler, Sys, Steps) ->
           false ->
             Change =
               case {sets:size(PidSet0), sets:size(PidSet1)} of
-                {Size, Size} ->
-                  none;
                 {0, _} ->
                   {init, sets:to_list(PidSet1)};
                 {Size0, Size1} when Size0 < Size1 ->
-                  [ChangePid] = sets:to_list(sets:subtract(PidSet1, PidSet0)),
-                  {add, ChangePid};
+                  [AddedPid] = sets:to_list(sets:subtract(PidSet1, PidSet0)),
+                  {add, AddedPid};
                 {Size0, Size1} when Size0 > Size1 ->
-                  [ChangePid] = sets:to_list(sets:subtract(PidSet0, PidSet1)),
-                  {remove, ChangePid}
+                  [RemovedPid] = sets:to_list(sets:subtract(PidSet0, PidSet1)),
+                  {remove, RemovedPid};
+                {Size, Size} ->
+                  case {sets:to_list(sets:subtract(PidSet1, PidSet0)), sets:to_list(sets:subtract(PidSet0, PidSet1))} of
+                    {[], []} -> none;
+                    {[AddedPid], [RemovedPid]} -> {update, AddedPid, RemovedPid}
+                  end
               end,
             {Pid, PidQueue1} = SchedFun(PidQueue0, Change),
             Sys1 =

--- a/test/cauder_scheduler_tests.erl
+++ b/test/cauder_scheduler_tests.erl
@@ -5,24 +5,24 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
--define(_assertScheduling(ExpectItem, ExpectList, Expr),
-  fun() -> {Item, Queue} = Expr, [?_assertEqual(ExpectItem, Item), ?_assertEqual(ExpectList, queue:to_list(Queue))] end).
-
-
 scheduler_round_robin_test_() ->
   Q0 = queue:new(),
   Q1 = queue:from_list([a, b, c, d]),
   [
-    ?_assertScheduling(a, [b, c, d, a], scheduler_round_robin(Q0, {init, [a, b, c, d]})),
+    assertScheduling(a, [b, c, d, a], scheduler_round_robin(Q0, {init, [a, b, c, d]})),
     ?_assertError(empty, scheduler_round_robin(Q0, none)),
     ?_assertError(empty, scheduler_round_robin(Q0, {add, a})),
     ?_assertError(empty, scheduler_round_robin(Q0, {remove, a})),
+    ?_assertError(empty, scheduler_round_robin(Q0, {update, b, a})),
 
     ?_assertError(not_empty, scheduler_round_robin(Q1, {init, [a, b, c, d]})),
-    ?_assertScheduling(a, [b, c, d, a], scheduler_round_robin(Q1, none)),
-    ?_assertScheduling(a, [b, c, d, e, a], scheduler_round_robin(Q1, {add, e})),
-    ?_assertScheduling(a, [b, c, a], scheduler_round_robin(Q1, {remove, d})),
-    ?_assertError(not_tail, scheduler_round_robin(Q1, {remove, a}))
+    assertScheduling(a, [b, c, d, a], scheduler_round_robin(Q1, none)),
+    assertScheduling(a, [b, c, d, e, a], scheduler_round_robin(Q1, {add, e})),
+    assertScheduling(a, [b, c, a], scheduler_round_robin(Q1, {remove, d})),
+    ?_assertError(not_tail, scheduler_round_robin(Q1, {remove, a})),
+    assertScheduling(a, [b, c, x, a], scheduler_round_robin(Q1, {update, x, d})),
+
+    assertScheduling(b, [b], scheduler_round_robin(queue:from_list([a]), {update, b, a}))
   ].
 
 
@@ -30,14 +30,23 @@ scheduler_fcfs_test_() ->
   Q0 = queue:new(),
   Q1 = queue:from_list([a, b, c, d]),
   [
-    ?_assertScheduling(a, [a, b, c, d], scheduler_fcfs(Q0, {init, [a, b, c, d]})),
+    assertScheduling(a, [a, b, c, d], scheduler_fcfs(Q0, {init, [a, b, c, d]})),
     ?_assertError(empty, scheduler_fcfs(Q0, none)),
     ?_assertError(empty, scheduler_fcfs(Q0, {add, a})),
     ?_assertError(empty, scheduler_fcfs(Q0, {remove, a})),
+    ?_assertError(empty, scheduler_fcfs(Q0, {update, b, a})),
 
     ?_assertError(not_empty, scheduler_fcfs(Q1, {init, [a, b, c, d]})),
-    ?_assertScheduling(a, [a, b, c, d], scheduler_fcfs(Q1, none)),
-    ?_assertScheduling(a, [a, b, c, d, e], scheduler_fcfs(Q1, {add, e})),
+    assertScheduling(a, [a, b, c, d], scheduler_fcfs(Q1, none)),
+    assertScheduling(a, [a, b, c, d, e], scheduler_fcfs(Q1, {add, e})),
     ?_assertError(not_head, scheduler_fcfs(Q1, {remove, d})),
-    ?_assertScheduling(b, [b, c, d], scheduler_fcfs(Q1, {remove, a}))
+    assertScheduling(b, [b, c, d], scheduler_fcfs(Q1, {remove, a})),
+    assertScheduling(b, [b, c, d, x], scheduler_fcfs(Q1, {update, x, a})),
+
+    assertScheduling(b, [b], scheduler_fcfs(queue:from_list([a]), {update, b, a}))
   ].
+
+
+assertScheduling(ExpectItem, ExpectList, Expr) ->
+  {Item, Queue} = Expr,
+  [?_assertEqual(ExpectItem, Item), ?_assertEqual(ExpectList, queue:to_list(Queue))].


### PR DESCRIPTION
## Description

This bug caused the scheduler to skip some processes, or even block execution if the list of PIDs used by the scheduler had exactly one item and it was replaced by another.
All this was caused because only the sizes where compared between the old and new lists of PIDs, instead of comparing the actual elements.

## Changes

- Fix the bug
- Add tests
- Fix scheduler tests configuration
