### PR TITLE
Refactor `cauder_eval`

### DIFF
--- a/src/cauder_eval.erl
+++ b/src/cauder_eval.erl
@@ -39,31 +39,6 @@
 %%%=============================================================================
 
 %%------------------------------------------------------------------------------
-%% @doc Evaluates the first reducible expression from the given list.
-%%
-%% Evaluates the first reducible expression from the given list of expressions,
-%% given an environment and a call stack, then returns a record with the updated
-%% information and a label indicating the type of step performed.
-%%
-%% @see is_reducible/2
-
--spec expr_list(Bindings, Expressions, Stack) -> Result when
-    Bindings :: cauder_bindings:bindings(),
-    Expressions :: [cauder_syntax:abstract_expr()],
-    Stack :: cauder_stack:stack(),
-    Result :: cauder_eval:result().
-
-expr_list(Bs, [E | Es], Stk) ->
-    case is_reducible(E, Bs) of
-        true ->
-            R = #result{expr = Es1} = expr(Bs, E, Stk),
-            R#result{expr = Es1 ++ Es};
-        false ->
-            R = #result{expr = Es1} = expr_list(Bs, Es, Stk),
-            R#result{expr = [E | Es1]}
-    end.
-
-%%------------------------------------------------------------------------------
 %% @doc Evaluates the given sequence of expression.
 %%
 %% If the first expression in the sequence is reducible, then it is evaluated,
@@ -466,6 +441,31 @@ expr(Bs, E = {'orelse', Line, Lhs, Rhs}, Stk) ->
                             #result{env = Bs, expr = [{value, Line, Value}], stack = Stk}
                     end
             end
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Evaluates the first reducible expression from the given list.
+%%
+%% Evaluates the first reducible expression from the given list of expressions,
+%% given an environment and a call stack, then returns a record with the updated
+%% information and a label indicating the type of step performed.
+%%
+%% @see is_reducible/2
+
+-spec expr_list(Bindings, Expressions, Stack) -> Result when
+    Bindings :: cauder_bindings:bindings(),
+    Expressions :: [cauder_syntax:abstract_expr()],
+    Stack :: cauder_stack:stack(),
+    Result :: cauder_eval:result().
+
+expr_list(Bs, [E | Es], Stk) ->
+    case is_reducible(E, Bs) of
+        true ->
+            R = #result{expr = Es1} = expr(Bs, E, Stk),
+            R#result{expr = Es1 ++ Es};
+        false ->
+            R = #result{expr = Es1} = expr_list(Bs, Es, Stk),
+            R#result{expr = [E | Es1]}
     end.
 
 remote_call(M, F, As, Stk0, Line, Bs0) ->

--- a/src/cauder_eval.erl
+++ b/src/cauder_eval.erl
@@ -1,3 +1,11 @@
+%%%-----------------------------------------------------------------------------
+%%% @doc The CauDEr meta interpreter.
+%%% This module provides an interpreter for Erlang expressions.
+%%% The expressions are in the abstract syntax as returned by `cauder_syntax'.
+%%% @see erl_eval
+%%% @end
+%%%-----------------------------------------------------------------------------
+
 -module(cauder_eval).
 
 %% API
@@ -824,6 +832,8 @@ is_value({value, _, _}) -> true;
 is_value({cons, _, H, T}) -> is_value(H) andalso is_value(T);
 is_value({tuple, _, Es}) -> is_value(Es);
 is_value(E) when is_tuple(E) -> false.
+
+%%%=============================================================================
 
 -spec eval_and_update(Index, Expression, Bindings, Stack) -> Result when
     Index :: pos_integer(),

--- a/src/cauder_eval.erl
+++ b/src/cauder_eval.erl
@@ -4,7 +4,6 @@
 -export([exprs/3]).
 -export([is_value/1, is_reducible/2]).
 -export([match_receive_pid/6, match_receive_uid/4]).
--export([clause_line/3]).
 
 -include("cauder_message.hrl").
 -include("cauder_stack.hrl").
@@ -665,25 +664,6 @@ match_clause([{'clause', _, H, G, B} | Cs], Vals, Bs) ->
     end;
 match_clause([], _, _) ->
     nomatch.
-
--spec clause_line(Clauses, ValueList, Bindings) -> Line when
-    Clauses :: clauses(),
-    ValueList :: [term()],
-    Bindings :: cauder_bindings:bindings(),
-    Line :: non_neg_integer().
-
-clause_line([], _, _) ->
-    -1;
-clause_line([{'clause', Line, Ps, G, _} | Cs], Vals, Bs) ->
-    case match_list(Ps, Vals, Bs) of
-        {match, Bs1} ->
-            case guard_seq(G, Bs1) of
-                true -> Line;
-                false -> clause_line(Cs, Vals, Bs)
-            end;
-        nomatch ->
-            clause_line(Cs, Vals, Bs)
-    end.
 
 %% Tries to match a list of values against a list of patterns using the given environment.
 %% The list of values should have no variables.

--- a/src/cauder_eval.erl
+++ b/src/cauder_eval.erl
@@ -153,7 +153,7 @@ expr({'if', Line, Cs}, Bs, Stk0) ->
 expr(E = {'case', Line, A, Cs}, Bs0, Stk0) ->
     case is_reducible(A, Bs0) of
         true ->
-            eval_and_update({A, Bs0, Stk0}, {3, E});
+            eval_and_update(3, E, Bs0, Stk0);
         false ->
             case match_case(Cs, A, Bs0) of
                 {match, Body, Bs} ->
@@ -195,7 +195,7 @@ expr({'make_fun', Line, Name, Cs}, Bs, Stk0) ->
 expr(E = {bif, Line, M, F, As}, Bs, Stk) ->
     case is_reducible(As, Bs) of
         true ->
-            eval_and_update({As, Bs, Stk}, {5, E});
+            eval_and_update(5, E, Bs, Stk);
         false ->
             Value = apply(M, F, lists:map(fun concrete/1, As)),
             #result{env = Bs, expr = [{value, Line, Value}], stack = Stk}
@@ -215,7 +215,7 @@ expr({nodes, Line}, Bs, Stk) ->
 expr(E = {spawn, Line, Fun}, Bs, Stk) ->
     case is_reducible(Fun, Bs) of
         true ->
-            eval_and_update({Fun, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             Var = cauder_utils:temp_variable(Line),
             Label = #label_spawn_fun{var = Var, function = Fun},
@@ -224,11 +224,11 @@ expr(E = {spawn, Line, Fun}, Bs, Stk) ->
 expr(E = {spawn, Line, N, Fun}, Bs, Stk) ->
     case is_reducible(N, Bs) of
         true ->
-            eval_and_update({N, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             case is_reducible(Fun, Bs) of
                 true ->
-                    eval_and_update({Fun, Bs, Stk}, {4, E});
+                    eval_and_update(4, E, Bs, Stk);
                 false ->
                     Var = cauder_utils:temp_variable(Line),
                     Label = #label_spawn_fun{var = Var, node = concrete(N), function = Fun},
@@ -238,15 +238,15 @@ expr(E = {spawn, Line, N, Fun}, Bs, Stk) ->
 expr(E = {spawn, Line, M, F, As}, Bs, Stk) ->
     case is_reducible(M, Bs) of
         true ->
-            eval_and_update({M, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             case is_reducible(F, Bs) of
                 true ->
-                    eval_and_update({F, Bs, Stk}, {4, E});
+                    eval_and_update(4, E, Bs, Stk);
                 false ->
                     case is_reducible(As, Bs) of
                         true ->
-                            eval_and_update({As, Bs, Stk}, {5, E});
+                            eval_and_update(5, E, Bs, Stk);
                         false ->
                             Var = cauder_utils:temp_variable(Line),
                             Label = #label_spawn_mfa{
@@ -262,19 +262,19 @@ expr(E = {spawn, Line, M, F, As}, Bs, Stk) ->
 expr(E = {spawn, Line, N, M, F, As}, Bs, Stk) ->
     case is_reducible(N, Bs) of
         true ->
-            eval_and_update({N, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             case is_reducible(M, Bs) of
                 true ->
-                    eval_and_update({M, Bs, Stk}, {4, E});
+                    eval_and_update(4, E, Bs, Stk);
                 false ->
                     case is_reducible(F, Bs) of
                         true ->
-                            eval_and_update({F, Bs, Stk}, {5, E});
+                            eval_and_update(5, E, Bs, Stk);
                         false ->
                             case is_reducible(As, Bs) of
                                 true ->
-                                    eval_and_update({As, Bs, Stk}, {6, E});
+                                    eval_and_update(6, E, Bs, Stk);
                                 false ->
                                     Var = cauder_utils:temp_variable(Line),
                                     Label = #label_spawn_mfa{
@@ -292,7 +292,7 @@ expr(E = {spawn, Line, N, M, F, As}, Bs, Stk) ->
 expr(E = {start, Line, N}, Bs, Stk) ->
     case is_reducible(N, Bs) of
         true ->
-            eval_and_update({N, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             Var = cauder_utils:temp_variable(Line),
             Label = #label_start{var = Var, name = concrete(N)},
@@ -301,11 +301,11 @@ expr(E = {start, Line, N}, Bs, Stk) ->
 expr(E = {start, Line, H, N}, Bs, Stk) ->
     case is_reducible(H, Bs) of
         true ->
-            eval_and_update({H, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             case is_reducible(N, Bs) of
                 true ->
-                    eval_and_update({N, Bs, Stk}, {4, E});
+                    eval_and_update(4, E, Bs, Stk);
                 false ->
                     Var = cauder_utils:temp_variable(Line),
                     Label = #label_start{var = Var, name = concrete(N), host = concrete(H)},
@@ -315,11 +315,11 @@ expr(E = {start, Line, H, N}, Bs, Stk) ->
 expr(E = {Send, _, L, R}, Bs, Stk) when Send =:= 'send' orelse Send =:= 'send_op' ->
     case is_reducible(L, Bs) of
         true ->
-            eval_and_update({L, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             case is_reducible(R, Bs) of
                 true ->
-                    eval_and_update({R, Bs, Stk}, {4, E});
+                    eval_and_update(4, E, Bs, Stk);
                 false ->
                     Label = #label_send{dst = concrete(L), val = concrete(R)},
                     #result{env = Bs, expr = [R], stack = Stk, label = Label}
@@ -328,7 +328,7 @@ expr(E = {Send, _, L, R}, Bs, Stk) when Send =:= 'send' orelse Send =:= 'send_op
 expr(E = {local_call, Line, F, As}, Bs0, Stk0) ->
     case is_reducible(As, Bs0) of
         true ->
-            eval_and_update({As, Bs0, Stk0}, {4, E});
+            eval_and_update(4, E, Bs0, Stk0);
         false ->
             {ok, M} = cauder_stack:current_module(Stk0),
             A = length(As),
@@ -341,22 +341,22 @@ expr(E = {local_call, Line, F, As}, Bs0, Stk0) ->
     end;
 expr(E = {remote_call, Line, M, F, As}, Bs0, Stk0) ->
     case is_reducible(As, Bs0) of
-        true -> eval_and_update({As, Bs0, Stk0}, {5, E});
+        true -> eval_and_update(5, E, Bs0, Stk0);
         false -> remote_call(M, F, As, Stk0, Line, Bs0)
     end;
 % TODO Handle calls to self/0, spawn/1, spawn/3
 expr(E = {apply, Line, M0, F0, As}, Bs0, Stk0) ->
     case is_reducible(M0, Bs0) of
         true ->
-            eval_and_update({M0, Bs0, Stk0}, {3, E});
+            eval_and_update(3, E, Bs0, Stk0);
         false ->
             case is_reducible(F0, Bs0) of
                 true ->
-                    eval_and_update({F0, Bs0, Stk0}, {4, E});
+                    eval_and_update(4, E, Bs0, Stk0);
                 false ->
                     case is_reducible(As, Bs0) of
                         true ->
-                            eval_and_update({As, Bs0, Stk0}, {5, E});
+                            eval_and_update(5, E, Bs0, Stk0);
                         false ->
                             M = concrete(M0),
                             F = concrete(F0),
@@ -367,11 +367,11 @@ expr(E = {apply, Line, M0, F0, As}, Bs0, Stk0) ->
 expr(E = {apply_fun, Line, Fun, As}, Bs0, Stk0) ->
     case is_reducible(Fun, Bs0) of
         true ->
-            eval_and_update({Fun, Bs0, Stk0}, {3, E});
+            eval_and_update(3, E, Bs0, Stk0);
         false ->
             case is_reducible(As, Bs0) of
                 true ->
-                    eval_and_update({As, Bs0, Stk0}, {4, E});
+                    eval_and_update(4, E, Bs0, Stk0);
                 false ->
                     A = length(As),
                     {env, [{{M, F}, Bs1, Cs}]} = erlang:fun_info(concrete(Fun), env),
@@ -386,11 +386,11 @@ expr(E = {apply_fun, Line, Fun, As}, Bs0, Stk0) ->
 expr(E = {match, _, Lhs, Rhs}, Bs0, Stk) ->
     case is_reducible(Lhs, Bs0) of
         true ->
-            eval_and_update({Lhs, Bs0, Stk}, {3, E});
+            eval_and_update(3, E, Bs0, Stk);
         false ->
             case is_reducible(Rhs, Bs0) of
                 true ->
-                    eval_and_update({Rhs, Bs0, Stk}, {4, E});
+                    eval_and_update(4, E, Bs0, Stk);
                 false ->
                     case match([Lhs], [Rhs], Bs0) of
                         {match, Bs} -> #result{env = Bs, expr = [Rhs], stack = Stk};
@@ -401,7 +401,7 @@ expr(E = {match, _, Lhs, Rhs}, Bs0, Stk) ->
 expr(E = {op, Line, Op, As}, Bs, Stk) ->
     case is_reducible(As, Bs) of
         true ->
-            eval_and_update({As, Bs, Stk}, {4, E});
+            eval_and_update(4, E, Bs, Stk);
         false ->
             Value = apply(erlang, Op, lists:map(fun concrete/1, As)),
             #result{env = Bs, expr = [{value, Line, Value}], stack = Stk}
@@ -409,7 +409,7 @@ expr(E = {op, Line, Op, As}, Bs, Stk) ->
 expr(E = {'andalso', Line, Lhs, Rhs}, Bs, Stk) ->
     case is_reducible(Lhs, Bs) of
         true ->
-            eval_and_update({Lhs, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             case Lhs of
                 {value, _, false} ->
@@ -417,7 +417,7 @@ expr(E = {'andalso', Line, Lhs, Rhs}, Bs, Stk) ->
                 {value, _, true} ->
                     case is_reducible(Rhs, Bs) of
                         true ->
-                            eval_and_update({Rhs, Bs, Stk}, {4, E});
+                            eval_and_update(4, E, Bs, Stk);
                         false ->
                             Value = apply(erlang, 'and', [concrete(Lhs), concrete(Rhs)]),
                             #result{env = Bs, expr = [{value, Line, Value}], stack = Stk}
@@ -427,7 +427,7 @@ expr(E = {'andalso', Line, Lhs, Rhs}, Bs, Stk) ->
 expr(E = {'orelse', Line, Lhs, Rhs}, Bs, Stk) ->
     case is_reducible(Lhs, Bs) of
         true ->
-            eval_and_update({Lhs, Bs, Stk}, {3, E});
+            eval_and_update(3, E, Bs, Stk);
         false ->
             case Lhs of
                 {value, _, true} ->
@@ -435,7 +435,7 @@ expr(E = {'orelse', Line, Lhs, Rhs}, Bs, Stk) ->
                 {value, _, false} ->
                     case is_reducible(Rhs, Bs) of
                         true ->
-                            eval_and_update({Rhs, Bs, Stk}, {4, E});
+                            eval_and_update(4, E, Bs, Stk);
                         false ->
                             Value = apply(erlang, 'or', [concrete(Lhs), concrete(Rhs)]),
                             #result{env = Bs, expr = [{value, Line, Value}], stack = Stk}
@@ -824,17 +824,19 @@ is_value({cons, _, H, T}) -> is_value(H) andalso is_value(T);
 is_value({tuple, _, Es}) -> is_value(Es);
 is_value(E) when is_tuple(E) -> false.
 
--spec eval_and_update({Expression | [Expression], Bindings, Stack}, {Index, Tuple}) -> Result when
+-spec eval_and_update(Index, Expression, Bindings, Stack) -> Result when
+    Index :: pos_integer(),
     Expression :: cauder_syntax:abstract_expr(),
     Bindings :: cauder_bindings:bindings(),
     Stack :: cauder_stack:stack(),
-    Index :: pos_integer(),
-    Tuple :: tuple(),
     Result :: cauder_eval:result().
 
-eval_and_update({Es, Bs, Stk}, {Index, Tuple}) when is_list(Es) ->
-    R = #result{expr = Es1} = expr_list(Es, Bs, Stk),
-    R#result{expr = [setelement(Index, Tuple, Es1)]};
-eval_and_update({E, Bs, Stk}, {Index, Tuple}) ->
-    R = #result{expr = [E1]} = expr(E, Bs, Stk),
-    R#result{expr = [setelement(Index, Tuple, E1)]}.
+eval_and_update(N, Expr, Bs, Stk) ->
+    case element(N, Expr) of
+        Es when is_list(Es) ->
+            R = #result{expr = Es1} = expr_list(Es, Bs, Stk),
+            R#result{expr = [setelement(N, Expr, Es1)]};
+        E ->
+            R = #result{expr = [E1]} = expr(E, Bs, Stk),
+            R#result{expr = [setelement(N, Expr, E1)]}
+    end.

--- a/src/cauder_semantics_forwards.erl
+++ b/src/cauder_semantics_forwards.erl
@@ -39,7 +39,7 @@
 
 step(Pid, Sys, Sched, Mode) ->
     #process{stack = Stk0, env = Bs0, expr = Es0} = cauder_pool:get(Pid, Sys#system.pool),
-    Result = cauder_eval:exprs(Bs0, Es0, Stk0),
+    Result = cauder_eval:exprs(Es0, Bs0, Stk0),
     case Result#result.label of
         #label_tau{} ->
             rule_local(Pid, Result, Sys);
@@ -439,11 +439,11 @@ rule_receive(
     Sched,
     #system{mail = Mail, pool = Pool, log = Log0} = Sys
 ) ->
-    {{Bs1, Es1, {Msg, QPos}, Mail1}, Log1} =
+    {{Es1, {Msg, QPos}, Mail1, Bs1}, Log1} =
         case Mode of
             normal ->
-                Match = cauder_eval:match_receive_pid(Cs, Bs, Pid, Mail, Sched, Sys),
-                {_, _, {#message{uid = Uid}, _}, _} = Match,
+                Match = cauder_eval:match_receive_pid(Cs, Pid, Mail, Bs, Sched, Sys),
+                {_, {#message{uid = Uid}, _}, _, _} = Match,
                 %% If the chosen message is the same specified in the log don't invalidate the log
                 Log =
                     case cauder_log:pop_receive(Pid, Log0) of
@@ -453,7 +453,7 @@ rule_receive(
                 {Match, Log};
             replay ->
                 {#log_receive{uid = Uid}, Log} = cauder_log:pop_receive(Pid, Log0),
-                Match = cauder_eval:match_receive_uid(Cs, Bs, Uid, Mail),
+                Match = cauder_eval:match_receive_uid(Cs, Uid, Mail, Bs),
                 {Match, Log}
         end,
 
@@ -601,10 +601,10 @@ check_reducibility(Cs, Pid, #system{mail = Mail, log = Log} = Sys, Mode, 'receiv
     IsMatch =
         case Mode of
             normal ->
-                cauder_eval:match_receive_pid(Cs, Bs, Pid, Mail, ?SCHEDULER_Random, Sys) =/= nomatch;
+                cauder_eval:match_receive_pid(Cs, Pid, Mail, Bs, ?SCHEDULER_Random, Sys) =/= nomatch;
             replay ->
                 {value, #log_receive{uid = Uid}} = cauder_log:peek(Pid, Log),
-                cauder_eval:match_receive_uid(Cs, Bs, Uid, Mail) =/= nomatch
+                cauder_eval:match_receive_uid(Cs, Uid, Mail, Bs) =/= nomatch
         end,
     case IsMatch of
         true ->

--- a/src/cauder_semantics_forwards.erl
+++ b/src/cauder_semantics_forwards.erl
@@ -39,7 +39,7 @@
 
 step(Pid, Sys, Sched, Mode) ->
     #process{stack = Stk0, env = Bs0, expr = Es0} = cauder_pool:get(Pid, Sys#system.pool),
-    Result = cauder_eval:seq(Bs0, Es0, Stk0),
+    Result = cauder_eval:exprs(Bs0, Es0, Stk0),
     case Result#result.label of
         #label_tau{} ->
             rule_local(Pid, Result, Sys);
@@ -442,7 +442,7 @@ rule_receive(
     {{Bs1, Es1, {Msg, QPos}, Mail1}, Log1} =
         case Mode of
             normal ->
-                Match = cauder_eval:match_rec_pid(Cs, Bs, Pid, Mail, Sched, Sys),
+                Match = cauder_eval:match_receive_pid(Cs, Bs, Pid, Mail, Sched, Sys),
                 {_, _, {#message{uid = Uid}, _}, _} = Match,
                 %% If the chosen message is the same specified in the log don't invalidate the log
                 Log =
@@ -453,7 +453,7 @@ rule_receive(
                 {Match, Log};
             replay ->
                 {#log_receive{uid = Uid}, Log} = cauder_log:pop_receive(Pid, Log0),
-                Match = cauder_eval:match_rec_uid(Cs, Bs, Uid, Mail),
+                Match = cauder_eval:match_receive_uid(Cs, Bs, Uid, Mail),
                 {Match, Log}
         end,
 
@@ -601,10 +601,10 @@ check_reducibility(Cs, Pid, #system{mail = Mail, log = Log} = Sys, Mode, 'receiv
     IsMatch =
         case Mode of
             normal ->
-                cauder_eval:match_rec_pid(Cs, Bs, Pid, Mail, ?SCHEDULER_Random, Sys) =/= nomatch;
+                cauder_eval:match_receive_pid(Cs, Bs, Pid, Mail, ?SCHEDULER_Random, Sys) =/= nomatch;
             replay ->
                 {value, #log_receive{uid = Uid}} = cauder_log:peek(Pid, Log),
-                cauder_eval:match_rec_uid(Cs, Bs, Uid, Mail) =/= nomatch
+                cauder_eval:match_receive_uid(Cs, Bs, Uid, Mail) =/= nomatch
         end,
     case IsMatch of
         true ->

--- a/src/cauder_semantics_forwards.erl
+++ b/src/cauder_semantics_forwards.erl
@@ -356,7 +356,7 @@ rule_spawn(
                     node = LogEntry#log_spawn.node,
                     pid = LogEntry#log_spawn.pid,
                     mfa = {M, F, length(As)},
-                    expr = [cauder_syntax:remote_call(M, F, lists:map(fun cauder_eval:abstract/1, As))]
+                    expr = [cauder_syntax:remote_call(M, F, lists:map(fun cauder_syntax:abstract/1, As))]
                 }
         end,
     TraceAction = #trace_spawn{

--- a/src/cauder_syntax.erl
+++ b/src/cauder_syntax.erl
@@ -10,6 +10,7 @@
 
 %% API
 -export([clauses/1, expr_list/1]).
+-export([abstract/1, concrete/1]).
 -export([replace_variable/3]).
 -export([to_abstract_expr/1]).
 -export([remote_call/3]).
@@ -572,6 +573,28 @@ exception(Class, Reason) ->
 %%%=============================================================================
 
 %%------------------------------------------------------------------------------
+%% @doc Converts the given Erlang term into its abstract form.
+
+-spec abstract(Term) -> Literal when
+    Term :: term(),
+    Literal :: cauder_syntax:af_literal().
+
+abstract(Value) -> {value, 0, Value}.
+
+%%------------------------------------------------------------------------------
+%% @doc Converts the given abstract literal element into the Erlang term that it
+%% represents.
+
+-spec concrete(Literal) -> Term when
+    Literal :: cauder_syntax:af_literal(),
+    Term :: term().
+
+concrete({value, _, Value}) -> Value;
+concrete({cons, _, {value, _, H}, {value, _, T}}) -> [H | T].
+
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
 %% @doc Replaces all occurrences of the given `Variable' in each one of the
 %% `Expressions' with the given literal `Value'.
 
@@ -601,14 +624,14 @@ replace_variable({cons, Line, H0, T0}, Var, Val) ->
     H = replace_variable(H0, Var, Val),
     T = replace_variable(T0, Var, Val),
     case cauder_eval:is_value(H) andalso cauder_eval:is_value(T) of
-        true -> {value, Line, [cauder_eval:concrete(H) | cauder_eval:concrete(T)]};
+        true -> {value, Line, [cauder_syntax:concrete(H) | cauder_syntax:concrete(T)]};
         false -> {cons, Line, H, T}
     end;
 replace_variable({tuple, Line, Es0}, Var, Val) ->
     Es = replace_variable(Es0, Var, Val),
     case cauder_eval:is_value(Es) of
         true ->
-            Tuple = list_to_tuple(lists:map(fun cauder_eval:concrete/1, Es)),
+            Tuple = list_to_tuple(lists:map(fun cauder_syntax:concrete/1, Es)),
             {value, Line, Tuple};
         false ->
             {tuple, Line, Es}

--- a/src/cauder_syntax.erl
+++ b/src/cauder_syntax.erl
@@ -868,6 +868,5 @@ set_line(Node, Line) -> erl_syntax:set_pos(Node, erl_anno:new(Line)).
 
 remote_call(M, F, As) ->
     A = length(As),
-    {_, Cs} = cauder_utils:fundef_lookup({M, F, A}),
-    Line = cauder_eval:clause_line(Cs, As, cauder_bindings:new()),
+    {_, [{'clause', Line, _Ps, _G, _B} | _]} = cauder_utils:fundef_lookup({M, F, A}),
     {remote_call, Line, M, F, lists:map(fun(V) -> setelement(2, V, Line) end, As)}.

--- a/src/cauder_syntax.erl
+++ b/src/cauder_syntax.erl
@@ -846,5 +846,5 @@ set_line(Node, Line) -> erl_syntax:set_pos(Node, erl_anno:new(Line)).
 remote_call(M, F, As) ->
     A = length(As),
     {_, Cs} = cauder_utils:fundef_lookup({M, F, A}),
-    Line = cauder_eval:clause_line(cauder_bindings:new(), Cs, As),
+    Line = cauder_eval:clause_line(Cs, As, cauder_bindings:new()),
     {remote_call, Line, M, F, lists:map(fun(V) -> setelement(2, V, Line) end, As)}.


### PR DESCRIPTION
## Description

Refactor the `cauder_eval` module to match more closely the structure of the `erl_eval` module.

## Changes

- Refactor, rename and reorder some functions
- Move `abstract/1` and `concrete/1` from `cauder_eval` to `cauder_syntax`
- Remove `clause_line/3` function

## Checklist

- [x] Follows styleguide
- [x] Branch is up to date
- [x] Passed unit tests